### PR TITLE
Recsim env

### DIFF
--- a/RDDL/recsim_ecosystem_welfare.rddl
+++ b/RDDL/recsim_ecosystem_welfare.rddl
@@ -66,7 +66,7 @@ domain recsim_ecosystem_welfare {
 
  	action-preconditions {
 
-		forall_{?c : consumer} [(sum_{?i : item} recommend(?c, ?i)) == 1];
+		//forall_{?c : consumer} [(sum_{?i : item} recommend(?c, ?i)) == 1];
 	};
 }
 


### PR DESCRIPTION
Fix interm declaration to avoid referring to primed values, temporarily comment out action constraint as grounder doesn't seem to support it yet.