### PR TITLE
Rams branch

### DIFF
--- a/Grounder/RDDLGrounder.py
+++ b/Grounder/RDDLGrounder.py
@@ -291,7 +291,7 @@ class RDDLGrounder(Grounder):
       names.append(grounded_name)
       grounded_name_to_params_dict[grounded_name] = variation
     if return_grounding_param_dict:
-      return names,grounded_name_to_params_dict
+      return names, grounded_name_to_params_dict
     else: # in some calls to _generate_name, we do not care about the param dict, hence this
       return names
 
@@ -356,8 +356,8 @@ class RDDLGrounder(Grounder):
       if pvariable.arity > 0:
         # In line below, if we leave as an iterator object, will be empty after one iteration. Hence "list(.)"
         variations = list(self._ground_objects(pvariable.param_types))
-        grounded,grounded_name_to_params_dict = \
-            self._generate_grounded_names(name, variations, return_grounding_param_dict=True)
+        grounded, grounded_name_to_params_dict = self._generate_grounded_names(name,
+                                                    variations, return_grounding_param_dict=True)
       else:
         grounded = [name]
         grounded_name_to_params_dict = {name:[]}
@@ -380,7 +380,7 @@ class RDDLGrounder(Grounder):
           warnings.warn('No conditional prob func found for ' + name)
 
         for g in grounded:
-          grounded_cpf = self._ground_single_cpf( cpf, g,grounded_name_to_params_dict[g])
+          grounded_cpf = self._ground_single_cpf( cpf, g, grounded_name_to_params_dict[g])
           all_grounded_cpfs.append(grounded_cpf)
           next_state = g + '\''  # update to grounded version, satisfied single-variables too (i.e. not a type)
           self.states[g] = pvariable.default
@@ -398,7 +398,7 @@ class RDDLGrounder(Grounder):
         if cpf is None:
           warnings.warn('No conditional prob func found for ' + name)
         for g in grounded:
-          grounded_cpf = self._ground_single_cpf( cpf, g,grounded_name_to_params_dict[name])
+          grounded_cpf = self._ground_single_cpf( cpf, g, grounded_name_to_params_dict[name])
           all_grounded_cpfs.append(grounded_cpf)
           self.derived[g] = pvariable.default
           self.cpfs[g] = grounded_cpf
@@ -419,7 +419,7 @@ class RDDLGrounder(Grounder):
         if cpf is None:
           warnings.warn('No conditional prob func found for ' + name)
         for g in grounded:
-          grounded_cpf = self._ground_single_cpf( cpf, g,grounded_name_to_params_dict[name])
+          grounded_cpf = self._ground_single_cpf( cpf, g, grounded_name_to_params_dict[name])
           all_grounded_cpfs.append(grounded_cpf)
           self.interm[g] = pvariable.default
           self.cpfs[g] = grounded_cpf
@@ -433,7 +433,7 @@ class RDDLGrounder(Grounder):
     self.AST.domain.cpfs = (self.AST.domain.cpfs[0], all_grounded_cpfs
                            )  # replacing the previous lifted entries
 
-  def _ground_single_cpf(self, cpf, variable,variable_args):
+  def _ground_single_cpf(self, cpf, variable, variable_args):
     """Map arguments to actual objects."""
     args = cpf.pvar[1][1]
     if args is None:
@@ -519,7 +519,7 @@ class RDDLGrounder(Grounder):
         new_expr = Expression((operation_string, tuple(new_children)))
       else:  # Handling the min and max case.
         # this is done by comparing two at a time, and recursively calling with the remainder of the list
-        # keeping the one that "wins" the comparison. Eg: if (a > b) then (>, [a,rest of list]) else (>, [b,rest of list])
+        # keeping the one that "wins" the comparison. Eg: if (a > b) then (>, [a, rest of list]) else (>, [b, rest of list])
         # I assume if they are equal, we have a default behavior in the simulator (eg: take first arg)
         lhs_updated_dict = copy.deepcopy(original_dict)
         lhs_updated_dict.update(
@@ -595,7 +595,7 @@ class RDDLGrounder(Grounder):
       aggreg_recursive_operation_string = AGGREG_OP_TO_STRING_DICT[aggreg_type]
       # TODO: only for average operation, we need to first "/ n " for all others
       # we need to decide the recursive operation symbol "+" or "*" and iterate.
-      # First let's collect the instances like (?x,?y) = (x1,y3) that satisfy,
+      # First let's collect the instances like (?x,?y) = (x1, y3) that satisfy,
       # the set definition passed in.
       object_instances_list = []
       instances_def_args = []


### PR DESCRIPTION
(1) updated _generate_name function to optionally return a mapping from grounded_name to parameter dict.
This dict is returned only if an argument to generate_name(.) is set to true. By default it is false, as we may not always care about the parameter_dict outside of initial grounding. 

(2) renamed _generate_name to be _generate_grounded_name ... I'm a fan of very precise naming, even if it's a bit verbose