### PR TITLE
Fix UnicodeDecodeError for differently encoded files

### DIFF
--- a/pyRDDLGym/core/parser/reader.py
+++ b/pyRDDLGym/core/parser/reader.py
@@ -2,43 +2,57 @@ import re
 
 from pyRDDLGym.core.debug.exception import RDDLParseError
 
+REPLACEMENT_CHAR_BYTES = b"\xef\xbf\xbd"
+
 
 class RDDLReader(object):
-
-    comment = r'\/\/.*?\n'
-    comment_ws = r'(\s*?\n\s*?)+'
-    domain_block = r'(?s)domain.*?\{.*?pvariables.*?cpfs.*?reward.*?;.*?\}[^;]'
-    nonfluent_in_domain = r'(?s)\{\s*?non-fluent,.*?\};'
-    nonfluent_block = r'(?s)non-fluents[^=]*?\{.*?\}[^;]'
-    instance_block = r'(?s)instance.*?\{.*\}[^;]'
+    comment = r"\/\/.*?\n"
+    comment_ws = r"(\s*?\n\s*?)+"
+    domain_block = r"(?s)domain.*?\{.*?pvariables.*?cpfs.*?reward.*?;.*?\}[^;]"
+    nonfluent_in_domain = r"(?s)\{\s*?non-fluent,.*?\};"
+    nonfluent_block = r"(?s)non-fluents[^=]*?\{.*?\}[^;]"
+    instance_block = r"(?s)instance.*?\{.*\}[^;]"
 
     def __init__(self, dom, inst=None):
-        with open(dom) as file:
+        with open(dom, encoding="utf-8", errors="replace") as file:
             dom_txt = file.read()
         dom_txt = self._remove_comments(dom_txt)
-        dom_txt = dom_txt + '\n'
+        dom_txt = dom_txt + "\n"
 
         if inst is not None:
-            with open(inst) as file:
+            with open(inst, encoding="utf-8", errors="replace") as file:
                 inst_txt = file.read()
             inst_txt = self._remove_comments(inst_txt)
-            dom_txt = dom_txt + '\n\n' + inst_txt + '\n'
+            dom_txt = dom_txt + "\n\n" + inst_txt + "\n"
+
+        # check for decoding errors
+        byte_data = dom_txt.encode("utf-8")
+        if REPLACEMENT_CHAR_BYTES in byte_data:
+            raise RDDLParseError(
+                "UnicodeDecodeError: Invalid byte sequence encountered in file after removing comments."
+            )
 
         # inspect rddl if three block are present - domain, non-fluent, instance
         m = re.search(self.domain_block, dom_txt)
         if m is None:
-            raise RDDLParseError('domain {...} block is missing or contains a syntax error.')
+            raise RDDLParseError(
+                "domain {...} block is missing or contains a syntax error."
+            )
 
         domaintxt = m.group(0)
         m = re.search(self.nonfluent_in_domain, domaintxt)
         if m is not None:
             m = re.search(self.nonfluent_block, dom_txt)
             if m is None:
-                raise RDDLParseError('non-fluents {...} block is missing or contains a syntax error.')
+                raise RDDLParseError(
+                    "non-fluents {...} block is missing or contains a syntax error."
+                )
 
         m = re.search(self.instance_block, dom_txt)
         if m is None:
-            raise RDDLParseError('instance {...} block is missing or contains a syntax error.')
+            raise RDDLParseError(
+                "instance {...} block is missing or contains a syntax error."
+            )
 
         self.dom_txt = dom_txt
 
@@ -47,6 +61,6 @@ class RDDLReader(object):
         return self.dom_txt
 
     def _remove_comments(self, txt):
-        txt = re.sub(self.comment, '\n', txt)
-        txt = re.sub(self.comment_ws, '\n', txt)
+        txt = re.sub(self.comment, "\n", txt)
+        txt = re.sub(self.comment_ws, "\n", txt)
         return txt

--- a/pyRDDLGym/core/parser/reader.py
+++ b/pyRDDLGym/core/parser/reader.py
@@ -29,7 +29,10 @@ class RDDLReader(object):
         byte_data = dom_txt.encode("utf-8")
         if REPLACEMENT_CHAR_BYTES in byte_data:
             raise RDDLParseError(
-                "UnicodeDecodeError: Invalid byte sequence encountered in file after removing comments."
+                (
+                    "UnicodeDecodeError: Invalid byte sequence encountered",
+                    "in file after removing comments.",
+                )
             )
 
         # inspect rddl if three block are present - domain, non-fluent, instance


### PR DESCRIPTION
Within the `rddlrepository` the following `domain.rddl` files are [cp1252](https://docs.python.org/3.8/library/codecs.html#standard-encodings) encoded:
- https://github.com/pyrddlgym-project/rddlrepository/blob/main/rddlrepository/archive/competitions/IPPC2014/TriangleTireworld/MDP/domain.rddl
- https://github.com/pyrddlgym-project/rddlrepository/blob/main/rddlrepository/archive/competitions/IPPC2014/TriangleTireworld/POMDP/domain.rddl
- https://github.com/pyrddlgym-project/rddlrepository/blob/main/rddlrepository/archive/competitions/IPPC2014/Tamarisk/MDP/domain.rddl
- https://github.com/pyrddlgym-project/rddlrepository/blob/main/rddlrepository/archive/competitions/IPPC2014/Tamarisk/POMDP/domain.rddl

Parsing each domain results in a `UnicodeDecodeError` because UTF-8 cannot decode specific byte sequences (e.g., Tamarisk: the dash in "351–63", line 22; TriangleTireWorld: the "é" in "Thiébaux", line 7). Since these encoding errors are expected to occur only within comments, my solution replaces invalid bytes with the  [replacement character](https://docs.python.org/3/library/codecs.html#codecs.replace_errors), allowing the file to be read successfully and comments to be removed afterwards.

However, if a `UnicodeDecodeError` occurs within a code block and persists after removing comments, a RDDLParserError is raised. To improve error reporting, we could implement this check both after parsing the domain and again after parsing the instance file.

Why is `inst` an optional argument of the `RDDLReader` class? Is it allowed to put the `non-fluents` and `instance` block into the `domain.rddl` file? 