### PR TITLE
Correct object valued pvars io

### DIFF
--- a/pyRDDLGym/core/compiler/model.py
+++ b/pyRDDLGym/core/compiler/model.py
@@ -583,6 +583,26 @@ class RDDLPlanningModel(metaclass=ABCMeta):
             grounded.update(self.ground_var_with_values(var, values))
         return grounded
     
+    def index_to_object_string_array(self, vtype: str, values: np.ndarray) -> np.ndarray:
+        '''Given an object type and integer values array, returns an array where each
+        element of the values array is replaced by the object string with that index.
+        '''
+
+        # get the objects of the type
+        objects = self.type_to_objects.get(vtype, None)
+        if objects is None:
+            raise RDDLTypeError(f'Type {vtype} is not valid, '
+                                f'must be one of {set(self.type_to_objects.keys())}.')
+        objects = np.asarray(objects)
+        
+        # make sure values is integer type
+        value_type = np.asarray(values).dtype
+        if not np.issubdtype(value_type, np.integer):
+            raise ValueError(f'values must be of integer type, got {value_type}.')
+        
+        # use fancy numpy indexing
+        return objects[values]
+    
     def is_compatible(self, var: str, objects: List[str]) -> bool:
         '''Determines whether or not the given variable can be assigned the
         list of objects in the given order to its type parameters.

--- a/pyRDDLGym/core/compiler/model.py
+++ b/pyRDDLGym/core/compiler/model.py
@@ -603,6 +603,28 @@ class RDDLPlanningModel(metaclass=ABCMeta):
         # use fancy numpy indexing
         return objects[values]
     
+    def object_string_to_index_array(self, vtype: str, values: np.ndarray) -> np.ndarray:
+        '''Given an object type and string object array, returns an array where each
+        element of the values array is replaced by the index of the object.
+        '''
+
+        # get the objects of the type
+        objects = self.type_to_objects.get(vtype, None)
+        if objects is None:
+            raise RDDLTypeError(f'Type {vtype} is not valid, '
+                                f'must be one of {set(self.type_to_objects.keys())}.')
+        
+        # make sure values is string type
+        values = np.asarray(values)
+        if values.dtype.type is not np.str_:
+            raise ValueError(f'values must of string type, got {values.dtype.type}.')
+        
+        # use fancy numpy indexing
+        result = np.zeros(shape=np.shape(values), dtype=int)
+        for obj in objects:
+            result[values == obj] = self.object_to_index[obj]
+        return result
+    
     def is_compatible(self, var: str, objects: List[str]) -> bool:
         '''Determines whether or not the given variable can be assigned the
         list of objects in the given order to its type parameters.

--- a/pyRDDLGym/core/compiler/model.py
+++ b/pyRDDLGym/core/compiler/model.py
@@ -620,9 +620,14 @@ class RDDLPlanningModel(metaclass=ABCMeta):
             raise ValueError(f'values must of string type, got {values.dtype.type}.')
         
         # use fancy numpy indexing
-        result = np.zeros(shape=np.shape(values), dtype=int)
+        result = np.full(shape=np.shape(values), fill_value=-1, dtype=int)
         for obj in objects:
             result[values == obj] = self.object_to_index[obj]
+        
+        # check that all values are filled in - those that are not are invalid
+        if np.any(result < 0):
+            raise RDDLInvalidObjectError(
+                f'{set(values[result < 0])} are not valid objects of type <{vtype}>.')
         return result
     
     def is_compatible(self, var: str, objects: List[str]) -> bool:

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -367,10 +367,18 @@ class RDDLSimulator:
         # update state
         self.state = {}
         for state in rddl.state_fluents:
+            
+            # convert object integer to string representation
+            state_values = subs[state]
+            ptype = self.rddl.variable_ranges[state]
+            if ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                state_values = self.rddl.index_to_object_string_array(ptype, state_values)
+
+            # optional grounding of state dictionary
             if keep_tensors:
-                self.state[state] = subs[state]
+                self.state[state] = state_values
             else:
-                self.state.update(rddl.ground_var_with_values(state, subs[state]))
+                self.state.update(rddl.ground_var_with_values(state, state_values))
         
         # update observation
         if self._pomdp:
@@ -409,20 +417,38 @@ class RDDLSimulator:
         # update state
         self.state = {}
         for (state, next_state) in rddl.next_state.items():
+
+            # set state = state' for the next epoch
             subs[state] = subs[next_state]
+
+            # convert object integer to string representation
+            state_values = subs[state]
+            ptype = self.rddl.variable_ranges[state]
+            if ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                state_values = self.rddl.index_to_object_string_array(ptype, state_values)
+
+            # optional grounding of state dictionary
             if keep_tensors:
-                self.state[state] = subs[state]
+                self.state[state] = state_values
             else:
-                self.state.update(rddl.ground_var_with_values(state, subs[state]))
+                self.state.update(rddl.ground_var_with_values(state, state_values))
         
         # update observation
         if self._pomdp: 
             obs = {}
             for var in rddl.observ_fluents:
+
+                # convert object integer to string representation
+                obs_values = subs[var]
+                ptype = self.rddl.variable_ranges[var]
+                if ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                    obs_values = self.rddl.index_to_object_string_array(ptype, obs_values)
+
+                # optional grounding of observ-fluent dictionary    
                 if keep_tensors:
-                    obs[var] = subs[var]
+                    obs[var] = obs_values
                 else:
-                    obs.update(rddl.ground_var_with_values(var, subs[var]))
+                    obs.update(rddl.ground_var_with_values(var, obs_values))
         else:
             obs = self.state
         

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -407,9 +407,9 @@ class RDDLSimulator:
             # convert object integer to string representation
             state_values = subs[state]
             if self.objects_as_strings:
-                ptype = self.rddl.variable_ranges[state]
+                ptype = rddl.variable_ranges[state]
                 if ptype not in RDDLValueInitializer.NUMPY_TYPES:
-                    state_values = self.rddl.index_to_object_string_array(ptype, state_values)
+                    state_values = rddl.index_to_object_string_array(ptype, state_values)
 
             # optional grounding of state dictionary
             if keep_tensors:
@@ -460,9 +460,9 @@ class RDDLSimulator:
             # convert object integer to string representation
             state_values = subs[state]
             if self.objects_as_strings:
-                ptype = self.rddl.variable_ranges[state]
+                ptype = rddl.variable_ranges[state]
                 if ptype not in RDDLValueInitializer.NUMPY_TYPES:
-                    state_values = self.rddl.index_to_object_string_array(ptype, state_values)
+                    state_values = rddl.index_to_object_string_array(ptype, state_values)
 
             # optional grounding of state dictionary
             if keep_tensors:
@@ -478,9 +478,9 @@ class RDDLSimulator:
                 # convert object integer to string representation
                 obs_values = subs[var]
                 if self.objects_as_strings:
-                    ptype = self.rddl.variable_ranges[var]
+                    ptype = rddl.variable_ranges[var]
                     if ptype not in RDDLValueInitializer.NUMPY_TYPES:
-                        obs_values = self.rddl.index_to_object_string_array(ptype, obs_values)
+                        obs_values = rddl.index_to_object_string_array(ptype, obs_values)
 
                 # optional grounding of observ-fluent dictionary    
                 if keep_tensors:

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -282,15 +282,15 @@ class RDDLSimulator:
                     raise RDDLInvalidActionError(
                         f'Grounded value specification of action-fluent <{ground_action}> '
                         f'received an array where a scalar value is required.')
-                elif ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                if ptype not in RDDLValueInitializer.NUMPY_TYPES:
                     value = rddl.object_to_index.get(value, value)
                 tensor = sim_actions[action]
                 RDDLSimulator._check_type(value, tensor.dtype, action, expr='')
                 indices = rddl.object_indices(objects)
-                if len(indices) != tensor.ndim:
+                if len(indices) != np.ndim(tensor):
                     raise RDDLInvalidActionError(
                         f'Grounded action-fluent name <{ground_action}> '
-                        f'requires {tensor.ndim} parameters, got {len(indices)}.')
+                        f'requires {np.ndim(tensor)} parameters, got {len(indices)}.')
                 tensor[indices] = value 
             
             # vectorized assignment

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -256,6 +256,8 @@ class RDDLSimulator:
             new_actions = self.noop_actions.copy()
             for (action, value) in actions.items(): 
                 if action in new_actions:
+                    RDDLSimulator._check_type(
+                        value, np.asarray(new_actions[action]).dtype, action, expr='')
                     new_actions[action] = value
                 else:
                     raise RDDLInvalidActionError(
@@ -269,6 +271,8 @@ class RDDLSimulator:
             for (action, value) in actions.items(): 
                 value = rddl.object_to_index.get(value, value)
                 if action in new_actions:  # no parameters
+                    RDDLSimulator._check_type(
+                        value, np.asarray(new_actions[action]).dtype, action, expr='')
                     new_actions[action] = value
                 else:  # must have parameters
                     var, objects = RDDLPlanningModel.parse_grounded(action)

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -268,15 +268,20 @@ class RDDLSimulator:
                     f'<{action}> is not a valid action-fluent, ' 
                     f'must be one of {set(sim_actions.keys())}.')
             
-            # grounded assignment
+            # boolean fix
             ptype = rddl.action_ranges[action]
+            if ptype == 'bool':
+                if np.shape(value):
+                    value = np.asarray(value, dtype=bool)
+                else:
+                    value = bool(value)
+            
+            # grounded assignment
             if objects:
                 if np.shape(value):
                     raise RDDLInvalidActionError(
                         f'Grounded value specification of action-fluent <{ground_action}> '
                         f'received an array where a scalar value is required.')
-                if ptype == 'bool':
-                    value = bool(value)
                 elif ptype not in RDDLValueInitializer.NUMPY_TYPES:
                     value = rddl.object_to_index.get(value, value)
                 tensor = sim_actions[action]
@@ -295,8 +300,6 @@ class RDDLSimulator:
                     raise RDDLInvalidActionError(
                         f'Value array for action <{action}> must be of shape '
                         f'{np.shape(tensor)}, got array of shape {np.shape(value)}.')      
-                if ptype == 'bool' and np.shape(value):
-                    value = np.asarray(value, dtype=bool)
                 if np.asarray(value).dtype.type is np.str_:
                     value = rddl.object_string_to_index_array(ptype, value)
                 RDDLSimulator._check_type(value, np.asarray(tensor).dtype, action, expr='')

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -28,7 +28,8 @@ class RDDLSimulator:
                  allow_synchronous_state: bool=True,
                  rng: np.random.Generator=np.random.default_rng(),
                  logger: Optional[Logger]=None,
-                 keep_tensors: bool=False) -> None:
+                 keep_tensors: bool=False,
+                 objects_as_strings: bool=True) -> None:
         '''Creates a new simulator for the given RDDL model.
         
         :param rddl: the RDDL model
@@ -37,12 +38,15 @@ class RDDLSimulator:
         :param logger: to log information about compilation to file
         :param keep_tensors: whether the sampler takes actions and
         returns state in numpy array form
+        :param objects_as_strings: whether to return object values as strings (defaults
+        to integer indices if False)
         '''
         self.rddl = rddl
         self.allow_synchronous_state = allow_synchronous_state
         self.rng = rng
         self.logger = logger
         self.keep_tensors = keep_tensors
+        self.objects_as_strings = objects_as_strings
         
         self._compile()
         
@@ -370,9 +374,10 @@ class RDDLSimulator:
             
             # convert object integer to string representation
             state_values = subs[state]
-            ptype = self.rddl.variable_ranges[state]
-            if ptype not in RDDLValueInitializer.NUMPY_TYPES:
-                state_values = self.rddl.index_to_object_string_array(ptype, state_values)
+            if self.objects_as_strings:
+                ptype = self.rddl.variable_ranges[state]
+                if ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                    state_values = self.rddl.index_to_object_string_array(ptype, state_values)
 
             # optional grounding of state dictionary
             if keep_tensors:
@@ -423,9 +428,10 @@ class RDDLSimulator:
 
             # convert object integer to string representation
             state_values = subs[state]
-            ptype = self.rddl.variable_ranges[state]
-            if ptype not in RDDLValueInitializer.NUMPY_TYPES:
-                state_values = self.rddl.index_to_object_string_array(ptype, state_values)
+            if self.objects_as_strings:
+                ptype = self.rddl.variable_ranges[state]
+                if ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                    state_values = self.rddl.index_to_object_string_array(ptype, state_values)
 
             # optional grounding of state dictionary
             if keep_tensors:
@@ -440,9 +446,10 @@ class RDDLSimulator:
 
                 # convert object integer to string representation
                 obs_values = subs[var]
-                ptype = self.rddl.variable_ranges[var]
-                if ptype not in RDDLValueInitializer.NUMPY_TYPES:
-                    obs_values = self.rddl.index_to_object_string_array(ptype, obs_values)
+                if self.objects_as_strings:
+                    ptype = self.rddl.variable_ranges[var]
+                    if ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                        obs_values = self.rddl.index_to_object_string_array(ptype, obs_values)
 
                 # optional grounding of observ-fluent dictionary    
                 if keep_tensors:

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -282,7 +282,19 @@ class RDDLSimulator:
                             f'<{action}> is not a valid action-fluent, ' 
                             f'must be one of {set(new_actions.keys())}.')
                     RDDLSimulator._check_type(value, tensor.dtype, action, expr='')            
-                    tensor[rddl.object_indices(objects)] = value                
+                    tensor[rddl.object_indices(objects)] = value     
+
+        # check action ranges for enum valued
+        for (action, values) in new_actions.items():
+            ptype = self.rddl.action_ranges[action]
+            if ptype not in RDDLValueInitializer.NUMPY_TYPES:
+                max_index = len(self.rddl.type_to_objects[ptype]) - 1
+                values_arr = np.asarray(values)
+                if not np.all((values_arr >= 0) & (values_arr <= max_index)):
+                    raise RDDLInvalidActionError(
+                        f'Values of action-fluent <{action}> of type <{ptype}> '
+                        f'are not valid, must be in the range [0, {max_index}].')
+
         return new_actions
     
     def check_default_action_count(self, actions: Args, 

--- a/pyRDDLGym/core/simulator.py
+++ b/pyRDDLGym/core/simulator.py
@@ -1373,7 +1373,8 @@ class RDDLSimulatorPrecompiled(RDDLSimulator):
                  levels: Dict[int, Set[str]], 
                  trace_info: object,
                  rng: np.random.Generator=np.random.default_rng(),
-                 keep_tensors: bool=False) -> None:
+                 keep_tensors: bool=False, 
+                 objects_as_strings: bool=True) -> None:
         self.init_values = init_values
         self.levels = levels
         self.traced = trace_info
@@ -1383,7 +1384,8 @@ class RDDLSimulatorPrecompiled(RDDLSimulator):
             allow_synchronous_state=True,
             rng=rng,
             logger=None,
-            keep_tensors=keep_tensors)        
+            keep_tensors=keep_tensors,
+            objects_as_strings=objects_as_strings)        
     
     def _compile(self):
         rddl = self.rddl

--- a/pyRDDLGym/core/visualizer/chart.py
+++ b/pyRDDLGym/core/visualizer/chart.py
@@ -174,6 +174,7 @@ class ChartVisualizer(BaseViz):
         states = {name: np.full(shape=shape, fill_value=np.nan)
                   for (name, shape) in self._state_shapes.items()}
         for (name, value) in state.items():
+            value = self._model.object_to_index.get(value, value)
             if name not in self._model.variable_params:  # lifted
                 var, objects = RDDLPlanningModel.parse_grounded(name)
                 states[var][self._model.object_indices(objects)] = value

--- a/pyRDDLGym/core/visualizer/heatmap.py
+++ b/pyRDDLGym/core/visualizer/heatmap.py
@@ -115,6 +115,7 @@ class HeatmapVisualizer(BaseViz):
         states = {name: np.full(shape=shape, fill_value=np.nan)
                   for (name, shape) in self._state_shapes.items()}
         for (name, value) in state.items():
+            value = self._model.object_to_index.get(value, value)
             if name not in self._model.variable_params:  # lifted
                 var, objects = RDDLPlanningModel.parse_grounded(name)
                 states[var][self._model.object_indices(objects)] = value


### PR DESCRIPTION
Not intended to provide full object-valued support for fluents, just ensures that enum-valued fluents work with string representations of objects instead of their integer representations (with option to use old behavior)