### PR TITLE
Add preprocessor codes

### DIFF
--- a/pyRDDLGym/core/env.py
+++ b/pyRDDLGym/core/env.py
@@ -15,6 +15,7 @@ from pyRDDLGym.core.debug.exception import (
 )
 from pyRDDLGym.core.debug.logger import Logger, SimLogger
 from pyRDDLGym.core.parser.parser import RDDLParser
+from pyRDDLGym.core.parser.preprocessor import RDDLPreprocessor
 from pyRDDLGym.core.parser.reader import RDDLReader
 from pyRDDLGym.core.simulator import RDDLSimulator
 from pyRDDLGym.core.visualizer.chart import ChartVisualizer
@@ -45,7 +46,8 @@ class RDDLEnv(gym.Env):
                  debug_path: Optional[str]=None,
                  log_path: Optional[str]=None,
                  backend: Type[RDDLSimulator]=RDDLSimulator,
-                 backend_kwargs: typing.Dict={}) -> None:
+                 backend_kwargs: typing.Dict={},
+                 preprocessor: Optional[RDDLPreprocessor]=None) -> None:
         '''Creates a new gym environment from the given RDDL domain + instance.
         
         :param domain: the RDDL domain
@@ -64,6 +66,7 @@ class RDDLEnv(gym.Env):
         simulation (currently supports numpy and Jax)
         :param backend_kwargs: dictionary of additional named arguments to
         pass to backend (must not include logger)
+        :param preprocessor: an optional RDDLPreprocessor to apply to the raw RDDL text
         '''
         super(RDDLEnv, self).__init__()
         
@@ -77,7 +80,7 @@ class RDDLEnv(gym.Env):
         if isinstance(domain, RDDLLiftedModel):
             self.model = domain
         else:
-            reader = RDDLReader(domain, instance)
+            reader = RDDLReader(domain, instance, preprocessor=preprocessor)
             domain = reader.rddltxt
             parser = RDDLParser(lexer=None, verbose=False)
             parser.build()

--- a/pyRDDLGym/core/parser/preprocessor.py
+++ b/pyRDDLGym/core/parser/preprocessor.py
@@ -14,7 +14,7 @@ class RDDLPreprocessor(metaclass=ABCMeta):
 
 
 class RDDLPreprocessorChain(RDDLPreprocessor):
-    ''''A chain of RDDL preprocessors that applies them sequentially.'''
+    '''A chain of RDDL preprocessors that applies them sequentially.'''
 
     def __init__(self, preprocessors: List[RDDLPreprocessor]):
         self.preprocessors = preprocessors

--- a/pyRDDLGym/core/parser/preprocessor.py
+++ b/pyRDDLGym/core/parser/preprocessor.py
@@ -1,6 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from itertools import product
 import re
+from typing import List
 
 
 class RDDLPreprocessor(metaclass=ABCMeta):
@@ -15,7 +16,7 @@ class RDDLPreprocessor(metaclass=ABCMeta):
 class RDDLPreprocessorChain(RDDLPreprocessor):
     ''''A chain of RDDL preprocessors that applies them sequentially.'''
 
-    def __init__(self, preprocessors: list[RDDLPreprocessor]):
+    def __init__(self, preprocessors: List[RDDLPreprocessor]):
         self.preprocessors = preprocessors
 
     def preprocess(self, rddl_str: str) -> str:
@@ -34,7 +35,7 @@ class RDDLPreprocessorIdentity(RDDLPreprocessor):
 class RDDLEnumPreprocessor(RDDLPreprocessor):
     '''A preprocessor that replaces enum definitions with their corresponding values.'''
 
-    OUTER = re.compile(r'\{\{\s*@([\w-]*)((?:\[\s*\d+\s*,\s*\d+\s*\])+)\s*\}\}')
+    OUTER = re.compile(r'\{\{\s*@([\w-]*)\s*((?:\[\s*\d+\s*,\s*\d+\s*\])+)\s*\}\}')
     RANGE  = re.compile(r'\[\s*(\d+)\s*,\s*(\d+)\s*\]')
 
     @staticmethod

--- a/pyRDDLGym/core/parser/preprocessor.py
+++ b/pyRDDLGym/core/parser/preprocessor.py
@@ -1,0 +1,51 @@
+from abc import ABCMeta, abstractmethod
+from itertools import product
+import re
+
+
+class RDDLPreprocessor(metaclass=ABCMeta):
+    '''Abstract base class for RDDL preprocessors.'''
+
+    @abstractmethod
+    def preprocess(self, rddl_str: str) -> str:
+        '''Preprocess the given RDDL string.'''
+        pass
+
+
+class RDDLPreprocessorChain(RDDLPreprocessor):
+    ''''A chain of RDDL preprocessors that applies them sequentially.'''
+
+    def __init__(self, preprocessors: list[RDDLPreprocessor]):
+        self.preprocessors = preprocessors
+
+    def preprocess(self, rddl_str: str) -> str:
+        for preprocessor in self.preprocessors:
+            rddl_str = preprocessor.preprocess(rddl_str)
+        return rddl_str
+
+
+class RDDLPreprocessorIdentity(RDDLPreprocessor):
+    '''A preprocessor that returns the input string unchanged.'''
+
+    def preprocess(self, rddl_str: str) -> str:
+        return rddl_str
+
+
+class RDDLEnumPreprocessor(RDDLPreprocessor):
+    '''A preprocessor that replaces enum definitions with their corresponding values.'''
+
+    OUTER = re.compile(r'\{\{\s*@([\w-]*)((?:\[\s*\d+\s*,\s*\d+\s*\])+)\s*\}\}')
+    RANGE  = re.compile(r'\[\s*(\d+)\s*,\s*(\d+)\s*\]')
+
+    @staticmethod
+    def _expand(match):
+        ident  = match.group(1)
+        ranges = [(int(a), int(b)) 
+                  for a, b in RDDLEnumPreprocessor.RANGE.findall(match.group(2))]
+        combos = product(*(range(lo, hi + 1) for lo, hi in ranges))
+        prefix = f'@{ident}' if ident else '@'
+        values = [prefix + '_'.join(str(i) for i in combo) for combo in combos]
+        return '{ ' + ', '.join(values) + ' }'
+
+    def preprocess(self, rddl_str: str) -> str:
+        return RDDLEnumPreprocessor.OUTER.sub(RDDLEnumPreprocessor._expand, rddl_str)

--- a/pyRDDLGym/core/parser/reader.py
+++ b/pyRDDLGym/core/parser/reader.py
@@ -1,6 +1,8 @@
 import re
+from typing import Optional
 
 from pyRDDLGym.core.debug.exception import RDDLParseError
+from pyRDDLGym.core.parser.preprocessor import RDDLPreprocessor
 
 REPLACEMENT_CHAR_BYTES = b"\xef\xbf\xbd"
 
@@ -13,12 +15,15 @@ class RDDLReader(object):
     nonfluent_block = r"(?s)non-fluents[^=]*?\{.*?\}[^;]"
     instance_block = r"(?s)instance.*?\{.*\}[^;]"
 
-    def __init__(self, dom, inst=None):
+    def __init__(self, dom, inst=None, preprocessor: Optional[RDDLPreprocessor]=None):
+       
+        # read domain and instance files, remove comments, and concatenate
         with open(dom, encoding="utf-8", errors="replace") as file:
             dom_txt = file.read()
         dom_txt = self._remove_comments(dom_txt)
         dom_txt = dom_txt + "\n"
 
+        # instance file is optional, but if provided, read and concatenate with domain
         if inst is not None:
             with open(inst, encoding="utf-8", errors="replace") as file:
                 inst_txt = file.read()
@@ -69,6 +74,10 @@ class RDDLReader(object):
             raise RDDLParseError(
                 "instance {...} block is missing or contains a syntax error."
             )
+
+        # apply preprocessor if provided
+        if preprocessor is not None:
+            dom_txt = preprocessor.preprocess(dom_txt)
 
         self.dom_txt = dom_txt
 

--- a/pyRDDLGym/core/server.py
+++ b/pyRDDLGym/core/server.py
@@ -17,7 +17,7 @@ class RDDLSimServer:
     designed to interact with rddlsim (https://github.com/ssanner/rddlsim)."""
 
     def __init__(self, domain: str, instance: str, numrounds: int, time: int, 
-                 port: int=2323, seed: Optional[int]=None):
+                 port: int=2323, seed: Optional[int]=None, **env_kwargs):
         # concatenate domain and instance files
         f = open(domain)
         self.task = f.read()
@@ -33,10 +33,11 @@ class RDDLSimServer:
 
         # create RDDLEnv
         print("INFO: Creating RDDL environment...", flush=True)
-        self.env = RDDLEnv(domain=domain, instance=instance)
+        self.env = RDDLEnv(domain=domain, instance=instance, **env_kwargs)
         if seed is not None:
             self.env.seed(seed)
         print("INFO: Created RDDL environment.\n", flush=True)
+        
         # initialize RDDLSimAgent
         self.roundsleft = numrounds
         self.currentround = 0

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
       url="https://github.com/pyrddlgym-project/pyRDDLGym",
       packages=find_packages(),
       install_requires=['ply', 'pillow>=9.2.0', 'matplotlib>=3.5.0', 'numpy>=1.22', 'gymnasium', 'pygame-ce', 'termcolor'],
-      python_requires=">=3.8,<3.15",
+      python_requires=">=3.9,<3.15",
       package_data={'': ['*.cfg']},
       include_package_data=True,
       classifiers=[


### PR DESCRIPTION
Add preprocessing of rddl text descriptions, e.g.` {{ @<ident> [x1,x2] }}` tags expand into `{ @identx1,, ... @identx2}`. This is advantageous for creating long enumerations e.g., `{ @x1, ... @x1000 }` programmatically. Such rules are applied prior to parsing and can be passed directly to `RDDLEnv` constructors as instances of `RDDLPreprocessor`.  